### PR TITLE
Feedback

### DIFF
--- a/TemplateIRDetector/publish-model.conf
+++ b/TemplateIRDetector/publish-model.conf
@@ -218,7 +218,7 @@ The preferred publisher is the Detector Assembly but the Detector HCD is an opti
 					  <ul>
 					  <li>READY - indicates the system can execute exposures.
 					  <li>BUSY  - indicates system is BUSY with the most likely reason being it is acquiring data
-					  <li>ERROR - indicates the detector system is in an error state. This could happen as a result of a command or due to a spontaneous failure. Corrective action is required. The operationalState is reset to READY if the failure is cleared or when the next exposure is started.
+					  <li>ERROR - indicates the detector system is in an error state. This could happen as a result of a command or due to a spontaneous failure. Corrective action is required. The operationalState is reset to READY if the failure is cleared or to BUSY when the next exposure is started.
 					  </ul>
 					"""
           enum = [ READY | BUSY | ERROR ]

--- a/TemplateIRDetector/publish-model.conf
+++ b/TemplateIRDetector/publish-model.conf
@@ -55,14 +55,14 @@ The preferred publisher is the Detector HCD but the Detector Assembly is an opti
 					name = read
 					description = "Read # of the readout within a ramp."
 					type = integer
-					minimum = 0
+					minimum = 1
 					maximum = 99999
 				}
 				{
 					name = ramp
 					description = "Ramp # which the readout belongs to."
 					type = integer
-					minimum = 0
+					minimum = 1
 					maximum = 99999
 				}
 				{
@@ -90,14 +90,14 @@ The preferred publisher is the Detector HCD but the Detector Assembly is an opti
           name = read
           description = "Read number of the failed readout within a ramp."
           type = integer
-          minimum = 0
+          minimum = 1
           maximum = 99999
         }
         {
           name = ramp
           description = "Ramp number which the readout failure belongs to."
           type = integer
-          minimum = 0
+          minimum = 1
           maximum = 99999
         }
         {
@@ -258,7 +258,7 @@ The preferred publisher is the Detector Assembly but the Detector HCD is an opti
             The integer total number of reads in the ramp. Value should be constant during an exposure. (Note: for multi-array detectors, it is assumed that all arrays work with the same configuration).
           """
           type = integer
-          minimum = 0
+          minimum = 2
           maximum = 99999
         }
         {
@@ -277,7 +277,7 @@ The preferred publisher is the Detector Assembly but the Detector HCD is an opti
             The integer total number of ramps in the current exposure. Value should be constant during an exposure.
           """
           type = integer
-          minimum = 0
+          minimum = 1
           maximum = 99999
         }
         {
@@ -295,7 +295,7 @@ The preferred publisher is the Detector Assembly but the Detector HCD is an opti
           description = "Length (as a float) in seconds of the current exposure.  For example: 1.25"
           type = float
           units = s
-          minimum = 0
+          exclusiveMinimum = 0
         }
         {
           name = remainingExposureTime


### PR DESCRIPTION
This pull request clarifies the following points:

- Read # and ramp # always start from 1 (not 0).
- There must be, at least, two readouts in one ramp.
- There must be, at least, one ramp in one exposure.
- Exposure duration cannot be 0.
- irDetectorExposureState.operationalState becomes BUSY during an exposure.